### PR TITLE
Fix cloning the bb8::Pool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,9 +390,16 @@ impl<M: ManageConnection> SharedPool<M> {
 }
 
 /// A generic connection pool.
-#[derive(Clone)]
 pub struct Pool<M: ManageConnection> {
     inner: Arc<SharedPool<M>>,
+}
+
+impl<M: ManageConnection> Clone for Pool<M> {
+    fn clone(&self) -> Self {
+        Pool {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<M: ManageConnection> fmt::Debug for Pool<M> {


### PR DESCRIPTION
bb8::Pool derivces `Clone`, but this does not make the struct cloneable
if the generic type parameter is not cloneable. However, the struct is
cloneable with any type parameter, because it internally uses an Arc.

Implementing `Clone` manually and calling the Arc::clone method does
the trick.

Background: I'm writing a [bb8 middleware for Gotham](https://github.com/ChristophWurst/gotham-middleware-bb8). There, I want to have a struct that holds a pool instance and that can be cloned:

```rust
struct MyMiddleware<M: ManageConnection>
    pool: Pool<M>,
}
```

However, I cannot use `.clone()` in generic implementations of the struct. With this patch, Rust knows that any instance of `Pool` implements `Clone` and thus allows me to call the method.