### PR TITLE
Make the futures returned by bb8 `Send`

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -53,7 +53,7 @@ impl bb8::ManageConnection for PostgresConnectionManager {
     fn is_valid
         (&self,
          conn: Self::Connection)
-         -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>> {
+         -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send> {
         conn.batch_execute("")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! bb8 is agnostic to the connection type it is managing. Implementors of the
 //! `ManageConnection` trait provide the database-specific logic to create and
 //! check the health of connections.
-#![deny(missing_docs,missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 extern crate futures;
 extern crate owning_ref;
@@ -25,12 +25,12 @@ use std::mem;
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
 use std::time::{Duration, Instant};
 
-use futures::{Future, IntoFuture, Stream};
 use futures::future::{lazy, loop_fn, ok, Either, Loop};
 use futures::stream::FuturesUnordered;
 use futures::sync::oneshot;
+use futures::{Future, IntoFuture, Stream};
 use owning_ref::OwningHandle;
-use tokio_core::reactor::{Interval, Handle, Remote, Timeout};
+use tokio_core::reactor::{Handle, Interval, Remote, Timeout};
 
 mod util;
 use util::*;
@@ -46,14 +46,15 @@ pub trait ManageConnection: Send + Sync + 'static {
     type Error: Send + 'static;
 
     /// Attempts to create a new connection.
-    fn connect(&self,
-               handle: Handle)
-               -> Box<Future<Item = Self::Connection, Error = Self::Error> + 'static>;
+    fn connect(
+        &self,
+        handle: Handle,
+    ) -> Box<Future<Item = Self::Connection, Error = Self::Error> + 'static>;
     /// Determines if the connection is still connected to the database.
-    fn is_valid
-        (&self,
-         conn: Self::Connection)
-         -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>>;
+    fn is_valid(
+        &self,
+        conn: Self::Connection,
+    ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>>;
     /// Synchronously determine if the connection is no longer usable, if possible.
     fn has_broken(&self, conn: &mut Self::Connection) -> bool;
     /// Produce an error representing a connection timeout.
@@ -206,8 +207,10 @@ impl<M: ManageConnection> Builder<M> {
     ///
     /// Defaults to 30 minutes.
     pub fn max_lifetime(mut self, max_lifetime: Option<Duration>) -> Builder<M> {
-        assert!(max_lifetime != Some(Duration::from_secs(0)),
-                "max_lifetime must be greater than zero!");
+        assert!(
+            max_lifetime != Some(Duration::from_secs(0)),
+            "max_lifetime must be greater than zero!"
+        );
         self.max_lifetime = max_lifetime;
         self
     }
@@ -219,8 +222,10 @@ impl<M: ManageConnection> Builder<M> {
     ///
     /// Defaults to 10 minutes.
     pub fn idle_timeout(mut self, idle_timeout: Option<Duration>) -> Builder<M> {
-        assert!(idle_timeout != Some(Duration::from_secs(0)),
-                "idle_timeout must be greater than zero!");
+        assert!(
+            idle_timeout != Some(Duration::from_secs(0)),
+            "idle_timeout must be greater than zero!"
+        );
         self.idle_timeout = idle_timeout;
         self
     }
@@ -232,8 +237,10 @@ impl<M: ManageConnection> Builder<M> {
     ///
     /// Defaults to 30 seconds.
     pub fn connection_timeout(mut self, connection_timeout: Duration) -> Builder<M> {
-        assert!(connection_timeout > Duration::from_secs(0),
-                "connection_timeout must be non-zero");
+        assert!(
+            connection_timeout > Duration::from_secs(0),
+            "connection_timeout must be non-zero"
+        );
         self.connection_timeout = connection_timeout;
         self
     }
@@ -254,13 +261,16 @@ impl<M: ManageConnection> Builder<M> {
         self
     }
 
-    fn build_inner(self,
-                   manager: M,
-                   event_loop: Remote)
-                   -> (Pool<M>, Box<Future<Item = (), Error = M::Error> + Send>) {
+    fn build_inner(
+        self,
+        manager: M,
+        event_loop: Remote,
+    ) -> (Pool<M>, Box<Future<Item = (), Error = M::Error> + Send>) {
         if let Some(min_idle) = self.min_idle {
-            assert!(self.max_size >= min_idle,
-                    "min_idle must be no larger than max_size");
+            assert!(
+                self.max_size >= min_idle,
+                "min_idle must be no larger than max_size"
+            );
         }
 
         let p = Pool::new_inner(self, manager, event_loop);
@@ -272,10 +282,11 @@ impl<M: ManageConnection> Builder<M> {
     ///
     /// The `Pool` will not be returned until it has established its configured
     /// minimum number of connections, or it times out.
-    pub fn build(self,
-                 manager: M,
-                 event_loop: Remote)
-                 -> Box<Future<Item = Pool<M>, Error = M::Error>> {
+    pub fn build(
+        self,
+        manager: M,
+        event_loop: Remote,
+    ) -> Box<Future<Item = Pool<M>, Error = M::Error>> {
         let (p, f) = self.build_inner(manager, event_loop);
         Box::new(f.map(|_| p))
     }
@@ -330,8 +341,9 @@ struct SharedPool<M: ManageConnection> {
 
 impl<M: ManageConnection> SharedPool<M> {
     fn proxy_or_dispatch<R>(&self, runnable: R)
-        where R: IntoFuture<Item = (), Error = ()>,
-              R::Future: Send + 'static
+    where
+        R: IntoFuture<Item = (), Error = ()>,
+        R::Future: Send + 'static,
     {
         let runnable = runnable.into_future();
         match self.event_loop.handle() {
@@ -343,18 +355,20 @@ impl<M: ManageConnection> SharedPool<M> {
     }
 
     fn sink_error<'a, E, F>(&self, f: F) -> Box<Future<Item = F::Item, Error = ()> + Send + 'a>
-        where F: Future<Error = E> + Send + 'a,
-              E: Into<M::Error>
+    where
+        F: Future<Error = E> + Send + 'a,
+        E: Into<M::Error>,
     {
         let sink = self.statics.error_sink.boxed_clone();
         Box::new(f.map_err(move |e| sink.sink(e.into())))
     }
 
     fn or_timeout<'a, F>(&self, f: F) -> Box<Future<Item = Option<F::Item>, Error = F::Error> + 'a>
-        where F: IntoFuture + Send,
-              F::Future: 'a,
-              F::Item: 'a,
-              F::Error: 'a
+    where
+        F: IntoFuture + Send,
+        F::Future: 'a,
+        F::Item: 'a,
+        F::Error: 'a,
     {
         let runnable = f.into_future();
         let event_loop = &self.event_loop;
@@ -362,13 +376,11 @@ impl<M: ManageConnection> SharedPool<M> {
             // We're being called on the event loop. We can set up a timeout directly.
             Some(handle) => {
                 let timeout = Timeout::new(self.statics.connection_timeout, &handle).unwrap();
-                Box::new(runnable.select2(timeout)
-                    .then(|r| match r {
-                        Ok(Either::A((item, _))) => Ok(Some(item)),
-                        Err(Either::A((error, _))) => Err(error),
-                        Ok(Either::B(_)) |
-                        Err(Either::B(_)) => Ok(None),
-                    }))
+                Box::new(runnable.select2(timeout).then(|r| match r {
+                    Ok(Either::A((item, _))) => Ok(Some(item)),
+                    Err(Either::A((error, _))) => Err(error),
+                    Ok(Either::B(_)) | Err(Either::B(_)) => Ok(None),
+                }))
             }
             // We're being called from somewhere else.
             None => {
@@ -378,13 +390,11 @@ impl<M: ManageConnection> SharedPool<M> {
                     let timeout = Timeout::new(timeout, handle).unwrap();
                     timeout.then(|_| tx.send(()))
                 });
-                Box::new(runnable.select2(rx)
-                    .then(|r| match r {
-                        Ok(Either::A((item, _))) => Ok(Some(item)),
-                        Err(Either::A((error, _))) => Err(error),
-                        Ok(Either::B(_)) |
-                        Err(Either::B(_)) => Ok(None),
-                    }))
+                Box::new(runnable.select2(rx).then(|r| match r {
+                    Ok(Either::A((item, _))) => Ok(Some(item)),
+                    Err(Either::A((error, _))) => Err(error),
+                    Ok(Either::B(_)) | Err(Either::B(_)) => Ok(None),
+                }))
             }
         };
         f
@@ -412,15 +422,18 @@ impl<M: ManageConnection> fmt::Debug for Pool<M> {
 
 // Outside of Pool to avoid borrow splitting issues on self
 // NB: This is called with the pool lock held.
-fn add_connection<M>(pool: &Arc<SharedPool<M>>,
-                     internals: &mut PoolInternals<M::Connection>)
-                     -> Box<Future<Item = (), Error = M::Error> + Send>
-    where M: ManageConnection
+fn add_connection<M>(
+    pool: &Arc<SharedPool<M>>,
+    internals: &mut PoolInternals<M::Connection>,
+) -> Box<Future<Item = (), Error = M::Error> + Send>
+where
+    M: ManageConnection,
 {
     assert!(internals.num_conns + internals.pending_conns < pool.statics.max_size);
     internals.pending_conns += 1;
     fn do_it<M>(pool: &Arc<SharedPool<M>>) -> Box<Future<Item = (), Error = M::Error> + Send>
-        where M: ManageConnection
+    where
+        M: ManageConnection,
     {
         let new_shared = Arc::downgrade(pool);
         let (tx, rx) = oneshot::channel();
@@ -472,10 +485,11 @@ fn add_connection<M>(pool: &Arc<SharedPool<M>>,
     do_it(pool)
 }
 
-fn lock_floating<M>
-    (pool: &Arc<SharedPool<M>>)
-     -> OwningHandle<Arc<SharedPool<M>>, MutexGuard<'static, PoolInternals<M::Connection>>>
-    where M: ManageConnection
+fn lock_floating<M>(
+    pool: &Arc<SharedPool<M>>,
+) -> OwningHandle<Arc<SharedPool<M>>, MutexGuard<'static, PoolInternals<M::Connection>>>
+where
+    M: ManageConnection,
 {
     OwningHandle::new_with_fn(pool.clone(), |pool| {
         let pool = unsafe { &*pool };
@@ -483,65 +497,73 @@ fn lock_floating<M>
     })
 }
 
-fn get_idle_connection<M>
-    (internals: OwningHandle<Arc<SharedPool<M>>, MutexGuard<'static, PoolInternals<M::Connection>>>)
-     -> Box<Future<Item = Conn<M::Connection>,
-                   Error = OwningHandle<Arc<SharedPool<M>>,
-                                        MutexGuard<'static, PoolInternals<M::Connection>>>>>
-    where M: ManageConnection
+fn get_idle_connection<M>(
+    internals: OwningHandle<Arc<SharedPool<M>>, MutexGuard<'static, PoolInternals<M::Connection>>>,
+) -> Box<
+    Future<
+        Item = Conn<M::Connection>,
+        Error = OwningHandle<Arc<SharedPool<M>>, MutexGuard<'static, PoolInternals<M::Connection>>>,
+    >,
+>
+where
+    M: ManageConnection,
 {
     Box::new(loop_fn(internals, |mut internals| {
-        let f: Box<Future<Item = Loop<_, _>, Error = _>> = if let Some(mut conn) = internals.conns
-            .pop_front() {
-            // Spin up a new connection if necessary to retain our minimum idle count
-            let pool = internals.as_owner().clone();
-            if internals.num_conns + internals.pending_conns < pool.statics.max_size {
-                let f = Pool::replenish_idle_connections_locked(&pool, &mut internals);
-                pool.proxy_or_dispatch(pool.sink_error(f));
-            }
+        let f: Box<Future<Item = Loop<_, _>, Error = _>> =
+            if let Some(mut conn) = internals.conns.pop_front() {
+                // Spin up a new connection if necessary to retain our minimum idle count
+                let pool = internals.as_owner().clone();
+                if internals.num_conns + internals.pending_conns < pool.statics.max_size {
+                    let f = Pool::replenish_idle_connections_locked(&pool, &mut internals);
+                    pool.proxy_or_dispatch(pool.sink_error(f));
+                }
 
-            // Go ahead and release the lock here.
-            mem::drop(internals);
+                // Go ahead and release the lock here.
+                mem::drop(internals);
 
-            if pool.statics.test_on_check_out {
-                let birth = conn.conn.birth;
-                Box::new(pool.manager
-                    .is_valid(conn.conn.conn)
-                    .then(move |r| match r {
-                        Ok(conn) => {
-                            Ok(Loop::Break(Conn {
-                                conn: conn,
-                                birth: birth,
-                            }))
-                        }
-                        Err((_, conn)) => {
-                            let mut lock = lock_floating(&pool);
-                            {
-                                drop_connections(&pool,
-                                                 OwningHandle::deref_once_mut(&mut lock),
-                                                 vec![conn]);
-                            }
-                            Ok(Loop::Continue(lock))
-                        }
-                    }))
+                if pool.statics.test_on_check_out {
+                    let birth = conn.conn.birth;
+                    Box::new(
+                        pool.manager
+                            .is_valid(conn.conn.conn)
+                            .then(move |r| match r {
+                                Ok(conn) => Ok(Loop::Break(Conn {
+                                    conn: conn,
+                                    birth: birth,
+                                })),
+                                Err((_, conn)) => {
+                                    let mut lock = lock_floating(&pool);
+                                    {
+                                        drop_connections(
+                                            &pool,
+                                            OwningHandle::deref_once_mut(&mut lock),
+                                            vec![conn],
+                                        );
+                                    }
+                                    Ok(Loop::Continue(lock))
+                                }
+                            }),
+                    )
+                } else {
+                    Box::new(Ok(Loop::Break(conn.conn)).into_future())
+                }
             } else {
-                Box::new(Ok(Loop::Break(conn.conn)).into_future())
-            }
-        } else {
-            Box::new(Err(internals).into_future())
-        };
+                Box::new(Err(internals).into_future())
+            };
         f
     }))
 }
 
 // Drop connections
 // NB: This is called with the pool lock held.
-fn drop_connections<'a, L, M>(pool: &Arc<SharedPool<M>>,
-                              mut internals: L,
-                              to_drop: Vec<M::Connection>)
-                              -> Box<Future<Item = (), Error = M::Error> + Send>
-    where M: ManageConnection,
-          L: BorrowMut<MutexGuard<'a, PoolInternals<M::Connection>>>
+fn drop_connections<'a, L, M>(
+    pool: &Arc<SharedPool<M>>,
+    mut internals: L,
+    to_drop: Vec<M::Connection>,
+) -> Box<Future<Item = (), Error = M::Error> + Send>
+where
+    M: ManageConnection,
+    L: BorrowMut<MutexGuard<'a, PoolInternals<M::Connection>>>,
 {
     let internals = internals.borrow_mut();
 
@@ -564,62 +586,67 @@ fn drop_connections<'a, L, M>(pool: &Arc<SharedPool<M>>,
     f
 }
 
-fn drop_idle_connections<'a, M>(pool: &Arc<SharedPool<M>>,
-                                internals: MutexGuard<'a, PoolInternals<M::Connection>>,
-                                to_drop: Vec<IdleConn<M::Connection>>)
-                                -> Box<Future<Item = (), Error = M::Error> + Send>
-    where M: ManageConnection
+fn drop_idle_connections<'a, M>(
+    pool: &Arc<SharedPool<M>>,
+    internals: MutexGuard<'a, PoolInternals<M::Connection>>,
+    to_drop: Vec<IdleConn<M::Connection>>,
+) -> Box<Future<Item = (), Error = M::Error> + Send>
+where
+    M: ManageConnection,
 {
-    let to_drop = to_drop.into_iter()
-        .map(|c| c.conn.conn)
-        .collect();
+    let to_drop = to_drop.into_iter().map(|c| c.conn.conn).collect();
     drop_connections(pool, internals, to_drop)
 }
 
 // Reap connections if necessary.
 // NB: This is called with the pool lock held.
-fn reap_connections<'a, M>(pool: &Arc<SharedPool<M>>,
-                           mut internals: MutexGuard<'a, PoolInternals<M::Connection>>)
-                           -> Box<Future<Item = (), Error = M::Error> + Send>
-    where M: ManageConnection
+fn reap_connections<'a, M>(
+    pool: &Arc<SharedPool<M>>,
+    mut internals: MutexGuard<'a, PoolInternals<M::Connection>>,
+) -> Box<Future<Item = (), Error = M::Error> + Send>
+where
+    M: ManageConnection,
 {
     let now = Instant::now();
-    let (to_drop, preserve) = internals.conns
-        .drain(..)
-        .partition2(|conn| {
-            let mut reap = false;
-            if let Some(timeout) = pool.statics.idle_timeout {
-                reap |= now - conn.idle_start >= timeout;
-            }
-            if let Some(lifetime) = pool.statics.max_lifetime {
-                reap |= now - conn.conn.birth >= lifetime;
-            }
-            reap
-        });
+    let (to_drop, preserve) = internals.conns.drain(..).partition2(|conn| {
+        let mut reap = false;
+        if let Some(timeout) = pool.statics.idle_timeout {
+            reap |= now - conn.idle_start >= timeout;
+        }
+        if let Some(lifetime) = pool.statics.max_lifetime {
+            reap |= now - conn.conn.birth >= lifetime;
+        }
+        reap
+    });
     internals.conns = preserve;
     drop_idle_connections(pool, internals, to_drop)
 }
 
 fn schedule_one_reaping<M>(handle: Handle, interval: Interval, weak_shared: Weak<SharedPool<M>>)
-    where M: ManageConnection
+where
+    M: ManageConnection,
 {
-    handle.clone()
-        .spawn(interval.into_future()
+    handle.clone().spawn(
+        interval
+            .into_future()
             .map_err(|_| ())
             .and_then(move |(_, interval)| {
-                let f: Box<Future<Item = (), Error = ()>> = match weak_shared.upgrade() {
-                    None => Box::new(ok(())),
-                    Some(shared) => {
-                        let locked = shared.internals.lock().unwrap();
-                        Box::new(shared.sink_error(reap_connections(&shared, locked))
-                            .then(|r| {
-                                schedule_one_reaping(handle, interval, weak_shared);
-                                r
-                            }))
-                    }
-                };
+                let f: Box<Future<Item = (), Error = ()>> =
+                    match weak_shared.upgrade() {
+                        None => Box::new(ok(())),
+                        Some(shared) => {
+                            let locked = shared.internals.lock().unwrap();
+                            Box::new(shared.sink_error(reap_connections(&shared, locked)).then(
+                                |r| {
+                                    schedule_one_reaping(handle, interval, weak_shared);
+                                    r
+                                },
+                            ))
+                        }
+                    };
                 f
-            }))
+            }),
+    )
 }
 
 impl<M: ManageConnection> Pool<M> {
@@ -652,28 +679,32 @@ impl<M: ManageConnection> Pool<M> {
     }
 
     fn proxy_or_dispatch<R>(&self, runnable: R)
-        where R: IntoFuture<Item = (), Error = ()>,
-              R::Future: Send + 'static
+    where
+        R: IntoFuture<Item = (), Error = ()>,
+        R::Future: Send + 'static,
     {
         self.inner.proxy_or_dispatch(runnable);
     }
 
     fn sink_error<'a, E, F>(&self, f: F) -> Box<Future<Item = F::Item, Error = ()> + Send + 'a>
-        where F: Future<Error = E> + Send + 'a,
-              E: Into<M::Error>
+    where
+        F: Future<Error = E> + Send + 'a,
+        E: Into<M::Error>,
     {
         self.inner.sink_error(f)
     }
 
-    fn replenish_idle_connections_locked(pool: &Arc<SharedPool<M>>,
-                                         internals: &mut PoolInternals<M::Connection>)
-                                         -> Box<Future<Item = (), Error = M::Error> + Send> {
+    fn replenish_idle_connections_locked(
+        pool: &Arc<SharedPool<M>>,
+        internals: &mut PoolInternals<M::Connection>,
+    ) -> Box<Future<Item = (), Error = M::Error> + Send> {
         let slots_available = pool.statics.max_size - internals.num_conns - internals.pending_conns;
         let idle = internals.conns.len() as u32;
         let desired = pool.statics.min_idle.unwrap_or(0);
-        let f = FuturesUnordered::from_iter((idle..
-                                             max(idle, min(desired, idle + slots_available)))
-            .map(|_| add_connection(pool, internals)));
+        let f = FuturesUnordered::from_iter(
+            (idle..max(idle, min(desired, idle + slots_available)))
+                .map(|_| add_connection(pool, internals)),
+        );
         Box::new(f.fold((), |_, _| Ok(())))
     }
 
@@ -704,17 +735,21 @@ impl<M: ManageConnection> Pool<M> {
     /// value need not be `Send` as it will live only on the tokio event loop.
     /// The return value of this function must be polled on the calling thread.
     pub fn run<'a, T, E, U, F>(&self, f: F) -> Box<Future<Item = T, Error = E> + 'a>
-        where F: FnOnce(M::Connection) -> U + 'a,
-              U: IntoFuture<Item = (T, M::Connection), Error = (E, M::Connection)> + 'a,
-              E: From<M::Error> + 'a,
-              T: 'a
+    where
+        F: FnOnce(M::Connection) -> U + 'a,
+        U: IntoFuture<Item = (T, M::Connection), Error = (E, M::Connection)> + 'a,
+        E: From<M::Error> + 'a,
+        T: 'a,
     {
         let inner = self.inner.clone();
         let inner2 = inner.clone();
-        Box::new(lazy(move || {
+        Box::new(
+            lazy(move || {
                 let lock = lock_floating(&inner);
                 get_idle_connection(lock).then(move |r| {
-                    let f: Box<Future<Item = Conn<M::Connection>, Error = M::Error>> = match r {
+                    let f: Box<
+                        Future<Item = Conn<M::Connection>, Error = M::Error>,
+                    > = match r {
                         Ok(conn) => Box::new(ok(conn)),
                         Err(mut locked) => {
                             let (tx, rx) = oneshot::channel();
@@ -724,43 +759,40 @@ impl<M: ManageConnection> Pool<M> {
                                 inner.proxy_or_dispatch(inner.sink_error(f));
                             }
 
-                            Box::new(inner.or_timeout(rx)
-                                .then(move |r| match r {
-                                    Ok(Some(conn)) => Ok(conn),
-                                    _ => Err(inner.manager.timed_out()),
-                                }))
+                            Box::new(inner.or_timeout(rx).then(move |r| match r {
+                                Ok(Some(conn)) => Ok(conn),
+                                _ => Err(inner.manager.timed_out()),
+                            }))
                         }
                     };
                     f
                 })
-            })
-            .map_err(|e| e.into())
+            }).map_err(|e| e.into())
             .and_then(|conn| {
                 let inner = inner2;
                 let birth = conn.birth;
-                f(conn.conn)
-                    .into_future()
-                    .then(move |r| {
-                        let (r, mut conn): (Result<_, E>, _) = match r {
-                            Ok((t, conn)) => (Ok(t), conn),
-                            Err((e, conn)) => (Err(e.into()), conn),
-                        };
-                        // Supposed to be fast, but do it before locking anyways.
-                        let broken = inner.manager.has_broken(&mut conn);
+                f(conn.conn).into_future().then(move |r| {
+                    let (r, mut conn): (Result<_, E>, _) = match r {
+                        Ok((t, conn)) => (Ok(t), conn),
+                        Err((e, conn)) => (Err(e.into()), conn),
+                    };
+                    // Supposed to be fast, but do it before locking anyways.
+                    let broken = inner.manager.has_broken(&mut conn);
 
-                        let mut locked = inner.internals.lock().unwrap();
-                        if broken {
-                            drop_connections(&inner, locked, vec![conn]);
-                        } else {
-                            let conn = IdleConn::make_idle(Conn {
-                                conn: conn,
-                                birth: birth,
-                            });
-                            locked.put_idle_conn(conn);
-                        }
-                        r
-                    })
-            }))
+                    let mut locked = inner.internals.lock().unwrap();
+                    if broken {
+                        drop_connections(&inner, locked, vec![conn]);
+                    } else {
+                        let conn = IdleConn::make_idle(Conn {
+                            conn: conn,
+                            birth: birth,
+                        });
+                        locked.put_idle_conn(conn);
+                    }
+                    r
+                })
+            }),
+        )
     }
 
     /// Get a new dedicated connection that will not be managed by the pool.
@@ -769,24 +801,23 @@ impl<M: ManageConnection> Pool<M> {
     ///
     /// This method allows reusing the manager's configuration but otherwise
     /// bypassing the pool
-    pub fn dedicated_connection(&self) -> Box<Future<Item = M::Connection, Error = M::Error> + 'static> {
+    pub fn dedicated_connection(
+        &self,
+    ) -> Box<Future<Item = M::Connection, Error = M::Error> + 'static> {
         let inner = self.inner.clone();
         let event_loop = &self.inner.event_loop;
 
         match event_loop.handle() {
             // We're being called on the event loop.
-            Some(handle) => {
-                Box::new(inner.manager.connect(handle))
-            },
+            Some(handle) => Box::new(inner.manager.connect(handle)),
             // We're being called from somewhere else.
             None => {
                 let (tx, rx) = oneshot::channel();
                 event_loop.spawn(move |handle| {
-                    inner.manager.connect(handle.clone())
-                        .then(move |r| {
-                            tx.send(r).ok();
-                            Ok(())
-                        })
+                    inner.manager.connect(handle.clone()).then(move |r| {
+                        tx.send(r).ok();
+                        Ok(())
+                    })
                 });
                 Box::new(rx.then(|r| r.unwrap()))
             }

--- a/src/test.rs
+++ b/src/test.rs
@@ -50,7 +50,7 @@ where
     fn is_valid(
         &self,
         conn: Self::Connection,
-    ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>> {
+    ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send> {
         Box::new(ok(conn))
     }
 
@@ -97,7 +97,7 @@ where
     fn is_valid(
         &self,
         conn: Self::Connection,
-    ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>> {
+    ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send> {
         Box::new(ok(conn))
     }
 
@@ -246,7 +246,8 @@ fn test_drop_on_broken() {
         fn is_valid(
             &self,
             conn: Self::Connection,
-        ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>> {
+        ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send>
+        {
             Box::new(ok(conn))
         }
 
@@ -372,7 +373,8 @@ fn test_now_invalid() {
         fn is_valid(
             &self,
             conn: Self::Connection,
-        ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>> {
+        ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send>
+        {
             let r = if INVALID.load(Ordering::SeqCst) {
                 Err((Error, conn))
             } else {
@@ -587,7 +589,8 @@ fn test_conns_drop_on_pool_drop() {
         fn is_valid(
             &self,
             conn: Self::Connection,
-        ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>> {
+        ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send>
+        {
             Box::new(ok(conn))
         }
 


### PR DESCRIPTION
Without this, it is challening to use the connection pool with Hyper. Hyper expects all of its futures to be Send, so to use the pool, a Send future would need to wait on a non-Send future. That may be possible, but I have no idea how to do it.

Most of the changes are simply adding the annotations. The one substantial change is inside `get_idle_connection` where we have to send an `Arc<SharedPool>` unlocked and do the locking within each future. That change adds locking/unlocking both inside the `get_idle_connection` `loop_fn` and inside `run`.

There are some unrelated `rustfmt` changes because I have it tied to my editor's save. They are in isolated commits, so it is easy to see the diffs without them. I can revert them if you don't want to deal with them.