### PR TITLE
Add connection pool for Redis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ tokio-core = "0.1"
 [workspace]
 members = [
     "postgres",
+    "redis",
 ]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bb8-redis"
+version = "0.1.0"
+authors = ["Daniel Smith <smith.daniel.br@gmail.com>", "Kyle Huey <khuey@kylehuey.com>"]
+
+[dependencies]
+bb8 = { path = ".." }
+futures = "0.1"
+tokio-core = "0.1"
+redis = "0.9"

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -1,0 +1,99 @@
+//! Redis support for the `bb8` connection pool.
+#![deny(missing_docs, missing_debug_implementations)]
+
+pub extern crate bb8;
+pub extern crate redis;
+
+extern crate futures;
+extern crate tokio_core;
+
+use futures::{Future, IntoFuture};
+use tokio_core::reactor::Handle;
+
+use redis::async::Connection;
+use redis::{Client, RedisError};
+
+use std::io;
+use std::option::Option;
+
+type Result<T> = std::result::Result<T, RedisError>;
+
+/// `RedisPool` is a convenience wrapper around `bb8::Pool` that hides the fact that
+/// `RedisConnectionManager` uses an `Option<Connection>` to smooth over the API incompatibility.
+#[derive(Debug)]
+pub struct RedisPool {
+    pool: bb8::Pool<RedisConnectionManager>,
+}
+
+impl RedisPool {
+    /// Constructs a new `RedisPool`, see the `bb8::Builder` documentation for description of
+    /// parameters.
+    pub fn new(pool: bb8::Pool<RedisConnectionManager>) -> RedisPool {
+        RedisPool { pool }
+    }
+
+    /// Run the function with a connection provided by the pool.
+    pub fn run<'a, T, E, U, F>(&self, f: F) -> impl Future<Item = T, Error = E> + Send + 'a
+    where
+        F: FnOnce(Connection) -> U + Send + 'a,
+        U: IntoFuture<Item = (Connection, T), Error = E> + 'a,
+        U::Future: Send,
+        E: From<RedisError> + Send + 'a,
+        T: Send + 'a,
+    {
+        let f = move |conn: Option<Connection>| {
+            let conn = conn.unwrap();
+            f(conn)
+                .into_future()
+                .map(|(conn, item)| (item, Some(conn)))
+                .map_err(|err| (err, None))
+        };
+        self.pool.run(f)
+    }
+}
+
+/// A `bb8::ManageConnection` for `redis::async::Connection`s.
+#[derive(Clone, Debug)]
+pub struct RedisConnectionManager {
+    client: Client,
+}
+
+impl RedisConnectionManager {
+    /// Create a new `RedisConnectionManager`.
+    pub fn new(client: Client) -> Result<RedisConnectionManager> {
+        Ok(RedisConnectionManager { client })
+    }
+}
+
+impl bb8::ManageConnection for RedisConnectionManager {
+    type Connection = Option<Connection>;
+    type Error = RedisError;
+
+    fn connect(
+        &self,
+        _handle: Handle,
+    ) -> Box<Future<Item = Self::Connection, Error = Self::Error> + 'static> {
+        Box::new(self.client.get_async_connection().map(|conn| Some(conn)))
+    }
+
+    fn is_valid(
+        &self,
+        conn: Self::Connection,
+    ) -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send> {
+        // The connection should only be None after a failure.
+        Box::new(
+            redis::cmd("PING")
+                .query_async(conn.unwrap())
+                .map_err(|err| (err, None))
+                .map(|(conn, ())| Some(conn)),
+        )
+    }
+
+    fn has_broken(&self, conn: &mut Self::Connection) -> bool {
+        conn.is_none()
+    }
+
+    fn timed_out(&self) -> Self::Error {
+        io::Error::new(io::ErrorKind::TimedOut, "RedisConnectionManager timed out").into()
+    }
+}


### PR DESCRIPTION
This creates a `RedisPool` and `RedisConnectionManager` type compatible with bb8. The `RedisPool` struct exists to paper over the small API incompatibility between the `redis` and `tokio-postgres` crates. While the `tokio-postgres` API always returns the connection, the `redis` API only returns the connection on success. The `RedisPool` hides that by creating a `RedisConnectionManager` that uses a `Option<Connection>` and returns `None` on failure. There's also a smaller incompatibility in that `tokio-postgres` uses `(T, Connection)` and `redis` uses `(Connection, T)`.

An example is forthcoming. I have used this code in a private project, so I just need to simplify the code to an example.

Depends upon https://github.com/khuey/bb8/pull/10