### PR TITLE
Fix redis dependency version

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Daniel Smith <smith.daniel.br@gmail.com>", "Kyle Huey <khuey@kylehue
 bb8 = { path = ".." }
 futures = "0.1"
 tokio = "0.1"
-redis = "^0.9"
+redis = ">=0.9"


### PR DESCRIPTION
Actually, after additional testing, it appears that neither caret nor tilde play well with 0.x versions. Therefore we must use `>=` to remain compatible with both redis 0.9 and 0.10.