### PR TITLE
minor tweaks

### DIFF
--- a/postgres/examples/static_select.rs
+++ b/postgres/examples/static_select.rs
@@ -32,7 +32,7 @@ fn main() {
                             let f = connection
                                 .query(&select, &[])
                                 .for_each(|row| {
-                                    println!("result: {}", row.get::<usize, String>(0));
+                                    println!("result: {}", row.get::<usize, i32>(0));
                                     Ok(())
                                 })
                                 .then(move |r| match r {

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::io;
 
 /// A `bb8::ManageConnection` for `tokio_postgres::Connection`s.
+#[derive(Clone)]
 pub struct PostgresConnectionManager<Tls>
 where
     Tls: MakeTlsConnect<Socket>,


### PR DESCRIPTION
I'm a bit new to Rust in general but here are two changes I've made locally that might also be helpful to others

* fixes type in example
* adds the `Clone` trait for  `PostgresConnectionManager`