### PR TITLE
Fix broken build

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/khuey/bb8"
 "with-uuid-0_7" = ["tokio-postgres/with-uuid-0_7"]
 
 [dependencies]
-bb8 = { path = "../" }
+bb8 = "0.3"
 futures = "0.1"
 tokio = "0.1"
 tokio-postgres = "0.4.0-rc.2"

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/khuey/bb8"
 "with-uuid-0_7" = ["tokio-postgres/with-uuid-0_7"]
 
 [dependencies]
-bb8 = "0.3"
+bb8 = { path = "../" }
 futures = "0.1"
 tokio = "0.1"
 tokio-postgres = "0.4.0-rc.2"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/khuey/bb8"
 
 [dependencies]
-bb8 = "0.3"
+bb8 = { path = "../" }
 futures = "0.1"
 tokio = "0.1"
-redis = ">=0.9"
+redis = "0.11"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/khuey/bb8"
 
 [dependencies]
-bb8 = { path = "../" }
+bb8 = "0.3"
 futures = "0.1"
 tokio = "0.1"
 redis = "0.11"

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -9,7 +9,7 @@ extern crate tokio;
 
 use futures::{Future, IntoFuture};
 
-use redis::async::Connection;
+use redis::aio::Connection;
 use redis::{Client, RedisError};
 
 use std::option::Option;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ impl<E> fmt::Display for RunError<E>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            RunError::User(ref err) => err.fmt(f),
+            RunError::User(ref err) => write!(f, "{}", err),
             RunError::TimedOut => write!(f, "Timed out in bb8"),
         }
     }


### PR DESCRIPTION
You specified dependency like this `redis = ">=0.9"`. Because of that, cargo automatically updated `redis` version to `0.11` in which some [breaking changes] were made. The name of the module `async` was renamed to `aio`.

Also `master` branch don't compile because of a error in `src/lib.rs`. This error I fixed too.


[breaking changes]: https://github.com/mitsuhiko/redis-rs/blob/master/CHANGELOG.md#breaking-changes