### PR TITLE
Retry connection establishment, defaulting to 3 tries

### DIFF
--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -264,6 +264,7 @@ async fn test_drop_on_broken() {
 async fn test_initialization_failure() {
     let manager = NthConnectionFailManager::<FakeConnection>::new(0);
     let e = Pool::builder()
+        .connection_timeout(Duration::from_secs(5))
         .max_size(1)
         .min_idle(Some(1))
         .build(manager)


### PR DESCRIPTION
This fixes the test from #45. @bbigras, would you like to review? You managed to find the one `TODO` in the library. @khuey, if you have some time to spare, review would be much appreciated too. I'd like to get this merged and then put out a first release soon after.