### PR TITLE
Is valid takes mut reference

### DIFF
--- a/bb8/src/lib.rs
+++ b/bb8/src/lib.rs
@@ -697,7 +697,6 @@ impl<M: ManageConnection> Pool<M> {
                     match inner.manager.is_valid(&mut conn).await {
                         Ok(()) => return Ok(Conn { conn, birth }),
                         Err(_) => {
-                            println!("Dropping connection...");
                             mem::drop(conn);
                             drop_connections(&inner, &mut internals, 1);
                         }

--- a/bb8/src/lib.rs
+++ b/bb8/src/lib.rs
@@ -695,7 +695,7 @@ impl<M: ManageConnection> Pool<M> {
                     let (mut conn, birth) = (conn.conn.conn, conn.conn.birth);
 
                     match inner.manager.is_valid(&mut conn).await {
-                        Ok(()) => return Ok(Conn { conn: conn, birth }),
+                        Ok(()) => return Ok(Conn { conn, birth }),
                         Err(_) => {
                             println!("Dropping connection...");
                             mem::drop(conn);

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -56,8 +56,8 @@ where
         Ok(Default::default())
     }
 
-    async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-        Ok(conn)
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     fn has_broken(&self, _: &mut Self::Connection) -> bool {
@@ -97,8 +97,8 @@ where
         }
     }
 
-    async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-        Ok(conn)
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     fn has_broken(&self, _: &mut Self::Connection) -> bool {
@@ -240,8 +240,8 @@ async fn test_drop_on_broken() {
             Ok(Default::default())
         }
 
-        async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-            Ok(conn)
+        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+            Ok(())
         }
 
         fn has_broken(&self, _: &mut Self::Connection) -> bool {
@@ -349,14 +349,14 @@ async fn test_now_invalid() {
             }
         }
 
-        async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
+        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
             println!("Called is_valid");
             if INVALID.load(Ordering::SeqCst) {
                 println!("Not");
                 Err(Error)
             } else {
                 println!("Is");
-                Ok(conn)
+                Ok(())
             }
         }
 
@@ -569,8 +569,8 @@ async fn test_conns_drop_on_pool_drop() {
             Ok(Connection)
         }
 
-        async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-            Ok(conn)
+        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+            Ok(())
         }
 
         fn has_broken(&self, _: &mut Self::Connection) -> bool {
@@ -621,10 +621,10 @@ async fn test_retry() {
             Ok(Connection)
         }
 
-        async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
+        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
             // only fail once so the retry should work
             if FAILED_ONCE.load(Ordering::SeqCst) {
-                Ok(conn)
+                Ok(())
             } else {
                 FAILED_ONCE.store(true, Ordering::SeqCst);
                 Err(Error)
@@ -675,8 +675,8 @@ async fn test_conn_fail_once() {
             }
         }
 
-        async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-            Ok(conn)
+        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+            Ok(())
         }
 
         fn has_broken(&self, _: &mut Self::Connection) -> bool {

--- a/bb8/tests/test.rs
+++ b/bb8/tests/test.rs
@@ -56,7 +56,7 @@ where
         Ok(Default::default())
     }
 
-    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+    async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -97,11 +97,11 @@ where
         }
     }
 
-    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+    async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+    fn has_broken(&self, _conn: &mut Self::Connection) -> bool {
         false
     }
 }
@@ -240,7 +240,7 @@ async fn test_drop_on_broken() {
             Ok(Default::default())
         }
 
-        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
             Ok(())
         }
 
@@ -349,7 +349,7 @@ async fn test_now_invalid() {
             }
         }
 
-        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
             println!("Called is_valid");
             if INVALID.load(Ordering::SeqCst) {
                 println!("Not");
@@ -569,7 +569,7 @@ async fn test_conns_drop_on_pool_drop() {
             Ok(Connection)
         }
 
-        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
             Ok(())
         }
 
@@ -621,7 +621,7 @@ async fn test_retry() {
             Ok(Connection)
         }
 
-        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
             // only fail once so the retry should work
             if FAILED_ONCE.load(Ordering::SeqCst) {
                 Ok(())
@@ -675,7 +675,7 @@ async fn test_conn_fail_once() {
             }
         }
 
-        async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        async fn is_valid(&self, _conn: &mut Self::Connection) -> Result<(), Self::Error> {
             Ok(())
         }
 

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 async-trait = "0.1"
 bb8 = { version = "0.4.0", path = "../bb8" }
 futures = "0.3"
-tokio = { version = "0.2", features = ["rt-core"] }
+tokio = { version = "0.2", features = ["rt-core", "macros"] }
 tokio-postgres = "0.5.1"
 
 [dev-dependencies]

--- a/postgres/examples/async_await.rs
+++ b/postgres/examples/async_await.rs
@@ -1,6 +1,3 @@
-use tokio;
-use tokio_postgres;
-
 use bb8::{Pool, RunError};
 use bb8_postgres::PostgresConnectionManager;
 

--- a/postgres/examples/hyper.rs
+++ b/postgres/examples/hyper.rs
@@ -1,12 +1,7 @@
-use hyper;
-
-use tokio_postgres;
-
 use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Error, Response, Server};
-use tokio;
 
 // Select some static data from a Postgres DB and return it via hyper.
 //

--- a/postgres/examples/static_select.rs
+++ b/postgres/examples/static_select.rs
@@ -1,6 +1,3 @@
-use tokio;
-use tokio_postgres;
-
 use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 

--- a/postgres/examples/txn.rs
+++ b/postgres/examples/txn.rs
@@ -1,6 +1,3 @@
-use tokio;
-use tokio_postgres;
-
 use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -70,8 +70,8 @@ where
             })
     }
 
-    async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-        conn.simple_query("").await.map(|_| conn)
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        conn.simple_query("").await.map(|_| ())
     }
 
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -117,9 +117,7 @@ impl bb8::ManageConnection for RedisConnectionManager {
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         // The connection should only be None after a failure.
-        redis::cmd("PING")
-            .query_async(conn.as_mut().unwrap())
-            .await
+        redis::cmd("PING").query_async(conn.as_mut().unwrap()).await
     }
 
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -115,12 +115,11 @@ impl bb8::ManageConnection for RedisConnectionManager {
         self.client.get_async_connection().await.map(Some)
     }
 
-    async fn is_valid(&self, mut conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         // The connection should only be None after a failure.
         redis::cmd("PING")
             .query_async(conn.as_mut().unwrap())
             .await
-            .map(|()| conn)
     }
 
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {


### PR DESCRIPTION
Change `is_valid()` to take the connection by reference. This simplifies the API, and lets the resulting connection be kept on error, allowing for features like CustomizeConnection to be implemented in the future. #63 