### PR TITLE
Disable default features for redis crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rs.bk
 Cargo.lock
 *~
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 **/*.rs.bk
 Cargo.lock
 *~
-/.idea/

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 async-trait = "0.1"
 bb8 = { version = "0.4.0", path = "../bb8" }
 futures = "0.3"
-redis = "0.17"
+redis = { version = "0.17", default-features = false, features = ["acl", "streams", "geospatial", "tokio-comp", "script"] }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros"] }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 async-trait = "0.1"
 bb8 = { version = "0.4.0", path = "../bb8" }
 futures = "0.3"
-redis = { version = "0.17", default-features = false, features = ["acl", "streams", "geospatial", "tokio-comp", "script"] }
+redis = { version = "0.17", default-features = false, features = ["tokio-comp"] }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros"] }


### PR DESCRIPTION
Since this library already depends on tokio I see no reason for the async-std feature of the redis crate to be enabled. It adds ~30 extra dependencies that have to be built even though the feature should never be used.