### PR TITLE
Add coverage job to github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,14 @@ jobs:
         with:
           command: clippy
           args: --workspace --all-targets -- -D warnings
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/tarpaulin@v0.1


### PR DESCRIPTION
This MR adds a minimal job to execute tarpaulin. It could be extended to upload the coverage file to codecov.io if a token is provided for this repo.

More on this github action here: https://github.com/marketplace/actions/rust-tarpaulin

And here is the current coverage:
![image](https://user-images.githubusercontent.com/12375782/94986314-1e660800-055e-11eb-9ece-869e644a49a1.png)